### PR TITLE
#918 Add ruby version 3.2.2 as default for the shell session

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ex
 
-asdf install ruby 3.2
+asdf install ruby 3.2.2
+asdf global ruby 3.2.2
 
 gem install shaman_cli
 shaman -v


### PR DESCRIPTION
The patch ruby version is needed since running the test failed with `ruby 3.2`. The resulting error was:
```
asdf install ruby 3.2
ruby-build: definition not found: 3.2
exit status 1
```
Adding the full ruby version (`3.2.2`) fixed this issue and the build was successfully added to tryout apps. 
The added build can be checked out [here](https://infinum.tryoutapps.com/bitrisetest/Zip/zipupload/1.0%20a).