### PR TITLE
Wrap ruby version as optional input parameter

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -ex
 
-asdf install ruby 3.2.2
-asdf global ruby 3.2.2
+if [[ "${ruby_version}" ]]; then
+	asdf install ruby "${ruby_version}"
+	asdf global ruby "${ruby_version}"
+fi
 
 gem install shaman_cli
 shaman -v

--- a/step.yml
+++ b/step.yml
@@ -92,9 +92,10 @@ inputs:
       description: |
         Release name used only if ZIP is uploaded to TryoutApps.
       is_required: false
-
-
-
-
-
-
+  - ruby_version:
+    opts:
+      title: "Ruby version"
+      category: Config
+      description: |
+        When set, a specific Ruby version will be installed on the machine. Otherwise, the default version from the machine will be used.
+      is_required: false


### PR DESCRIPTION
This PR adds logic for manually setting the ruby version as an input parameter from the Bitrise config section.