### PR TITLE
Modify step to install Shaman via Gemfile and Bundler

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -5,8 +5,7 @@ set -ex
 if [[ -f "${gemfile_path}" ]]; then
   echo "Gemfile already exists at ${gemfile_path}"
 
-  # Install gems using the existing Gemfile
-  BUNDLE_GEMFILE="${gemfile_path}" bundle install
+  BUNDLE_GEMFILE="${gemfile_path}"
 else
   # Create a new Gemfile with the specified content
   cat <<EOF > Gemfile
@@ -16,10 +15,10 @@ gem 'shaman_cli'
 EOF
 
   echo "Gemfile created!"
-
-  # Install gems using the new Gemfile
-  bundle install
 fi
+
+# Install gems using the new Gemfile
+bundle install
 
 shaman -v
 export SHAMAN_TOKEN=${shaman_token}

--- a/step.sh
+++ b/step.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
 set -ex
 
-if [[ "${ruby_version}" ]]; then
-	asdf install ruby "${ruby_version}"
-	asdf global ruby "${ruby_version}"
+# Check if the Gemfile already exists
+if [[ -f "${gemfile_path}" ]]; then
+  echo "Gemfile already exists at ${gemfile_path}"
+
+  # Install gems using the existing Gemfile
+  BUNDLE_GEMFILE="${gemfile_path}" bundle install
+else
+  # Create a new Gemfile with the specified content
+  cat <<EOF > Gemfile
+source "https://rubygems.org"
+
+gem 'shaman_cli'
+EOF
+
+  echo "Gemfile created!"
+
+  # Install gems using the new Gemfile
+  bundle install
 fi
 
-gem install shaman_cli
 shaman -v
 export SHAMAN_TOKEN=${shaman_token}
 

--- a/step.yml
+++ b/step.yml
@@ -92,10 +92,10 @@ inputs:
       description: |
         Release name used only if ZIP is uploaded to TryoutApps.
       is_required: false
-  - ruby_version:
+  - gemfile_path:
     opts:
-      title: "Ruby version"
+      title: "Path to a local Gemfile"
       category: Config
       description: |
-        When set, a specific Ruby version will be installed on the machine. Otherwise, the default version from the machine will be used.
+        When set, it specifies a local Gemfile used for installing Shaman. If not set, a default Gemfile is generated.
       is_required: false


### PR DESCRIPTION
**Problem:**
The problem was that the Shaman install was failing due to incorrect Ruby versions after the machine update. Setting specific Ruby versions worked, but since Bitrise is periodically changing the default Ruby versions on their machines, ideally, we would also need to update the Ruby versions we are using, or on each build, we would reinstall specific versions that might not be present on the machine anymore. 

**Solution:**
Changing direct gem installation with installation using a Gemfile and Bundler. The reasoning for this change:

-  Installing the plugin via the Gemfile and running bundle install ensures that the plugin is installed per project while direct installation using gem install shaman_cli installs the plugin globally on the machine. A project-specific installation is preferable because Bundler manages all dependencies within the project, ensuring they are resolved without conflicts.

- Since the ASDF version manager is a specific tool, if Bitrise updates the machine and replaces this version manager, our deployment step would break, requiring an update. Additionally, if Bitrise deployment were run on a local machine that lacks this tool, the step would fail I suppose.

- Using a Gemfile allows for better version management. If the Ruby team releases an update that introduces breaking changes, we can simply specify a previous version in the Gemfile until the issue is resolved. With direct installation, the latest version is always installed, removing this flexibility. While such issues should ideally not occur, having this level of control is an added benefit.

The step by default generates the Gemfile used for installing Shaman unless there is a local copy of the file in the project (this is a safety net in case we need to fix some specific issue, for example, point 3 above). 